### PR TITLE
Call to undefined method PHPUnit_Framework_AssertionFailedError::getComparisonFailure()

### DIFF
--- a/Extensions/TeamCity/TestListener.php
+++ b/Extensions/TeamCity/TestListener.php
@@ -118,7 +118,7 @@ class PHPUnit_Extensions_TeamCity_TestListener extends PHPUnit_Util_Printer impl
 
             /** @var $exception PHPUnit_Framework_ExpectationFailedException */
             $exception         = $failure->thrownException();
-            $comparisonFailure = $exception->getComparisonFailure();
+            $comparisonFailure = ($exception instanceof PHPUnit_Framework_ExpectationFailedException ? $exception->getComparisonFailure() : null);
             if ($comparisonFailure instanceof PHPUnit_Framework_ComparisonFailure) {
                 $array += array(
                     'expected' => $comparisonFailure->getExpectedAsString(),


### PR DESCRIPTION
Hello, Alexander!

I use:
- PHPUnit 3.6.11
- TeamCity 7.0.*, 7.1

And I have some problem with:
...
[14:46:19][Step 4/10] PHP Fatal error:  Call to undefined method PHPUnit_Framework_AssertionFailedError::getComparisonFailure() in /usr/share/pear/PHPUnit/Extensions/TeamCity/TestListener.php on line 121
[14:46:19][Step 4/10] PHP Stack trace:
[14:46:19][Step 4/10] PHP   1. {main}() /usr/bin/phpunit:0
...

I use this fix-commit to solve problem.
